### PR TITLE
BaSP-MR-105: classes bug spinner fails

### DIFF
--- a/src/Redux/classes/reducer.js
+++ b/src/Redux/classes/reducer.js
@@ -28,19 +28,44 @@ const classesReducer = (state = INITIAL_STATE, action) => {
         loading: false,
         error: action.payload
       };
+    case types.DELETE_CLASS_PENDING:
+      return {
+        ...state,
+        loading: true,
+        error: null
+      };
     case types.DELETE_CLASS_SUCCESS:
       return {
         ...state,
+        loading: false,
         data: {
           ...state.data,
           data: state.data.data.filter((gymClass) => gymClass._id !== action.payload)
         }
+      };
+    case types.DELETE_CLASS_ERROR:
+      return {
+        ...state,
+        loading: false,
+        error: action.payload
+      };
+    case types.PUT_CLASS_PENDING:
+      return {
+        ...state,
+        loading: true,
+        error: null
       };
     case types.PUT_CLASS_SUCCESS:
       return {
         ...state,
         loading: false,
         data: action.payload
+      };
+    case types.PUT_CLASS_ERROR:
+      return {
+        ...state,
+        loading: false,
+        error: action.payload
       };
     case types.POST_CLASS_PENDING:
       return {


### PR DESCRIPTION
Fix Bug: The spinner that should appear while loading the updated list of classes after deleting one of them, does not appear.