### PR TITLE
BaSP-MR-274: [Profiles and Shared Button] - Styles / Implementing MUI

### DIFF
--- a/src/Components/Admin/Profile/profile.module.css
+++ b/src/Components/Admin/Profile/profile.module.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   width: 100vh;
   border-radius: 20px;
-  box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.3);
+  box-shadow: 0px 6px 7px -3.5px rgba(0,0,0,0.2), 0px 12px 19px 1.5px rgba(0,0,0,0.14), 0px 4.5px 23px 4px rgba(0,0,0,0.12);
 }
 
 .formMembers {
@@ -61,8 +61,8 @@
 }
 
 .formTitleTwo {
-  color: #f9a414;
-  border-bottom: solid 2px #f9a414;
+  color: #157CAA;
+  border-bottom: solid 2px #157CAA;
   margin: 2rem 5rem 2rem 5rem;
   text-transform: uppercase;
   line-height: 3rem;

--- a/src/Components/Member/Profile/profile.module.css
+++ b/src/Components/Member/Profile/profile.module.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   width: 100vh;
   border-radius: 20px;
-  box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.3);
+  box-shadow: 0px 6px 7px -3.5px rgba(0,0,0,0.2), 0px 12px 19px 1.5px rgba(0,0,0,0.14), 0px 4.5px 23px 4px rgba(0,0,0,0.12);
 }
 
 .formMembers {
@@ -61,8 +61,8 @@
 }
 
 .formTitleTwo {
-  color: #f9a414;
-  border-bottom: solid 2px #f9a414;
+  color: #157CAA;
+  border-bottom: solid 2px #157CAA;
   margin: 2rem 5rem 2rem 5rem;
   text-transform: uppercase;
   line-height: 3rem;

--- a/src/Components/Shared/Button/button.module.css
+++ b/src/Components/Shared/Button/button.module.css
@@ -3,9 +3,9 @@
   padding: 0.9rem;
   margin-top: 1rem;
   margin-bottom: 2rem;
-  background-color: #157CAA;;
+  background-color: #157CAA;
   border: solid 1px;
-  border-color: #157CAA;;
+  border-color: #157CAA;
   color: white;
   text-align: center;
   font-size: 1rem;

--- a/src/Components/Shared/Button/index.jsx
+++ b/src/Components/Shared/Button/index.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import styles from './button.module.css';
 import { EditTooltip, DeleteTooltip } from './Tooltip/Tooltip';
+import { Button } from '@mui/material';
 
-const Button = ({ text, clickAction, type, info, testId }) => {
+const SharedButton = ({ text, clickAction, type, info, testId }) => {
   let buttonStyle = styles.button;
   let icon = null;
 
@@ -36,10 +37,16 @@ const Button = ({ text, clickAction, type, info, testId }) => {
       {icon}
     </div>
   ) : (
-    <button onClick={clickAction} type={info} className={buttonStyle} id={testId}>
+    <Button
+      variant="contained"
+      onClick={clickAction}
+      type={info}
+      className={buttonStyle}
+      id={testId}
+    >
       {text}
-    </button>
+    </Button>
   );
 };
 
-export default Button;
+export default SharedButton;

--- a/src/Components/Shared/Button/index.jsx
+++ b/src/Components/Shared/Button/index.jsx
@@ -5,6 +5,7 @@ import { Button } from '@mui/material';
 
 const SharedButton = ({ text, clickAction, type, info, testId }) => {
   let buttonStyle = styles.button;
+  let variant = 'contained';
   let icon = null;
 
   switch (type) {
@@ -12,6 +13,7 @@ const SharedButton = ({ text, clickAction, type, info, testId }) => {
       buttonStyle = styles.confirmButton;
       break;
     case 'cancel':
+      variant = 'outlined';
       buttonStyle = styles.cancelButton;
       break;
     case 'add':
@@ -37,13 +39,7 @@ const SharedButton = ({ text, clickAction, type, info, testId }) => {
       {icon}
     </div>
   ) : (
-    <Button
-      variant="contained"
-      onClick={clickAction}
-      type={info}
-      className={buttonStyle}
-      id={testId}
-    >
+    <Button variant={variant} onClick={clickAction} type={info} className={buttonStyle} id={testId}>
       {text}
     </Button>
   );

--- a/src/Components/Trainer/Profile/profile.module.css
+++ b/src/Components/Trainer/Profile/profile.module.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   width: 100vh;
   border-radius: 20px;
-  box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.3);
+  box-shadow: 0px 6px 7px -3.5px rgba(0,0,0,0.2), 0px 12px 19px 1.5px rgba(0,0,0,0.14), 0px 4.5px 23px 4px rgba(0,0,0,0.12);
 }
 
 .formMembers {
@@ -61,8 +61,8 @@
 }
 
 .formTitleTwo {
-  color: #f9a414;
-  border-bottom: solid 2px #f9a414;
+  color: #157CAA;
+  border-bottom: solid 2px #157CAA;
   margin: 2rem 5rem 2rem 5rem;
   text-transform: uppercase;
   line-height: 3rem;


### PR DESCRIPTION
Change the color of the titles and divider in Admin, Member and Trainer for #157CAA

Add this box-shadow to all profiles container: box-shadow: 0px 6px 7px -3.5px rgba(0,0,0,0.2), 0px 12px 19px 1.5px rgba(0,0,0,0.14), 0px 4.5px 23px 4px rgba(0,0,0,0.12);

Replace the buttons in the shared component for MUI Buttons
